### PR TITLE
Allow using pure go sqlite database implementations

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -24,6 +24,12 @@ func NewReader(dsn string) (*Reader, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewReaderWithDb(db)
+}
+
+// NewReaderWithDb returns a new Reader initialized with a sql.Database.
+// This is useful for instantiating alternative implementations of sqlite.
+func NewReaderWithDb(db *sql.DB) (*Reader, error) {
 	return &Reader{db: db}, nil
 }
 

--- a/reader.go
+++ b/reader.go
@@ -24,12 +24,12 @@ func NewReader(dsn string) (*Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewReaderWithDb(db)
+	return NewReaderWithDB(db)
 }
 
-// NewReaderWithDb returns a new Reader initialized with a sql.Database.
+// NewReaderWithDB returns a new Reader initialized with a sql.Database.
 // This is useful for instantiating alternative implementations of sqlite.
-func NewReaderWithDb(db *sql.DB) (*Reader, error) {
+func NewReaderWithDB(db *sql.DB) (*Reader, error) {
 	return &Reader{db: db}, nil
 }
 

--- a/writer.go
+++ b/writer.go
@@ -42,6 +42,17 @@ func NewWriter(dsn string) (*Writer, error) {
 	return &Writer{Reader: *r}, nil
 }
 
+// NewWriterWithDb returns a new Writer initialized with a sql.Database.
+// This is useful for instantiating alternative implementations of sqlite.
+func NewWriterWithDb(db *sql.DB) (*Reader, error) {
+	r, err := NewReaderWithDb(db)
+	if err != nil {
+		return nil, err
+	}
+	return &Writer{Reader: *r}, nil
+}
+
+
 // Close releases all resources with w.
 func (w *Writer) Close() error {
 	var err error

--- a/writer.go
+++ b/writer.go
@@ -44,14 +44,13 @@ func NewWriter(dsn string) (*Writer, error) {
 
 // NewWriterWithDb returns a new Writer initialized with a sql.Database.
 // This is useful for instantiating alternative implementations of sqlite.
-func NewWriterWithDb(db *sql.DB) (*Reader, error) {
+func NewWriterWithDb(db *sql.DB) (*Writer, error) {
 	r, err := NewReaderWithDb(db)
 	if err != nil {
 		return nil, err
 	}
 	return &Writer{Reader: *r}, nil
 }
-
 
 // Close releases all resources with w.
 func (w *Writer) Close() error {

--- a/writer.go
+++ b/writer.go
@@ -42,10 +42,10 @@ func NewWriter(dsn string) (*Writer, error) {
 	return &Writer{Reader: *r}, nil
 }
 
-// NewWriterWithDb returns a new Writer initialized with a sql.Database.
+// NewWriterWithDB returns a new Writer initialized with a sql.Database.
 // This is useful for instantiating alternative implementations of sqlite.
-func NewWriterWithDb(db *sql.DB) (*Writer, error) {
-	r, err := NewReaderWithDb(db)
+func NewWriterWithDB(db *sql.DB) (*Writer, error) {
+	r, err := NewReaderWithDB(db)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The current approach requires that the default sqlite3 driver is always used. This driver requires C (CGO) to compile a binary.

Instead, you can do something like this with this change that uses a pure Go sqlite library:

```golang
import (
	"database/sql"
	_ "github.com/glebarez/go-sqlite"
)

func main() {
  	mbtilesDB, err := sql.Open("sqlite", "path/to/file.mbtiles")
	if err != nil {
		panic(err)
	}
	reader, err := mbtiles.NewReaderWithDB(mbtilesDB)
	if err != nil {
		panic(err)
	}
}
```